### PR TITLE
Add instructions for Swift Runtime install

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ To install:
 brew install hyperjeff/tools/shuffle
 ```
 
+You may also need to install the [Swift 5 Runtime Support for Command Line Tools](https://support.apple.com/kb/DL1998?locale=en_US) from Apple.
+
 Subsequent updates via:
 ```
 brew upgrade shuffle


### PR DESCRIPTION
On installing `shuffle` through brew and running it for the first time I saw:

```
dyld: Library not loaded: @rpath/libswiftCore.dylib
  Referenced from: /usr/local/bin/shuffle
  Reason: image not found
Abort trap: 6
```

After some googling I found [the solution on stack overflow](https://stackoverflow.com/a/55572389). It looks like you might be able to avoid this situation with different built options as well.

This is on macOS 10.13.6.